### PR TITLE
fix: clear quizId when updating chapter content type

### DIFF
--- a/api/controllers/tutorial.controller.js
+++ b/api/controllers/tutorial.controller.js
@@ -227,8 +227,12 @@ export const updateChapter = async (req, res, next) => {
     if (contentType !== undefined) updateFields.contentType = contentType;
     if (initialCode !== undefined) updateFields.initialCode = initialCode;
     if (expectedOutput !== undefined) updateFields.expectedOutput = expectedOutput;
-    if (quizId !== undefined) {
-        updateFields.quizId = contentType === 'quiz' ? quizId : undefined;
+    if (contentType !== undefined && contentType !== 'quiz') {
+        // Ensure stale quiz references are removed when a chapter is
+        // converted from a quiz to another content type.
+        updateFields.quizId = undefined;
+    } else if (quizId !== undefined) {
+        updateFields.quizId = quizId;
     }
 
     try {


### PR DESCRIPTION
## Summary
- ensure updating a chapter from a quiz to another type clears any leftover quizId

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_68ba9dd9e5a8832b824d2ad039683185