### PR TITLE
Normalize diacritics in slug generation

### DIFF
--- a/api/utils/slug.js
+++ b/api/utils/slug.js
@@ -25,6 +25,11 @@ export function generateSlug(title) {
 
     return trimmed
         .toLowerCase()
+        // Normalize the string so diacritics are separate code points
+        // (e.g. "é" -> "e\u0301") allowing them to be stripped below.
+        .normalize('NFKD')
+        // Remove all diacritic marks that may remain after normalization
+        .replace(/[\u0300-\u036f]/g, '')
         // Treat underscores as hyphens for word separation
         .replace(/_/g, '-')
         // Remove all characters except letters, numbers, spaces and hyphens

--- a/api/utils/slug.test.js
+++ b/api/utils/slug.test.js
@@ -27,6 +27,12 @@ test('generateSlug returns empty string when given only whitespace', () => {
     assert.strictEqual(slug, '');
 });
 
+test('generateSlug strips diacritics from characters', () => {
+    const slug = generateSlug('Café déjà vu');
+    // The accented characters should be converted to their ASCII equivalents
+    assert.strictEqual(slug, 'cafe-deja-vu');
+});
+
 test('generateSlug throws an error when input is not a string', () => {
     assert.throws(() => generateSlug(123), {
         name: 'TypeError',


### PR DESCRIPTION
## Summary
- ensure slug generator normalizes and strips diacritics for accented characters
- test slug creation with accented input

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `node --test api/utils/slug.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68baa5e543f0832b84168f68cf31dbaf