### PR TITLE
Add call stack tracing to Python visualizer

### DIFF
--- a/client/src/components/ExecutionVisualizer.jsx
+++ b/client/src/components/ExecutionVisualizer.jsx
@@ -323,11 +323,22 @@ export default function ExecutionVisualizer() {
                 )}
                 {currentStep >= 0 && events[currentStep] && (
                     <div className="mb-4">
-                        <p className="font-semibold">Step {currentStep + 1} of {events.length} (line {events[currentStep].line})</p>
+                        <p className="font-semibold">Step {currentStep + 1} of {events.length} ({events[currentStep].event} at line {events[currentStep].line})</p>
                         <h4 className="font-semibold mt-2">Local Variables:</h4>
                         <pre className="text-sm bg-gray-100 dark:bg-gray-700 p-2 rounded max-h-24 overflow-auto">
                             <code>{JSON.stringify(events[currentStep].locals || {}, null, 2)}</code>
                         </pre>
+                        {events[currentStep].stack && (
+                            <>
+                                <h4 className="font-semibold mt-2">Call Stack:</h4>
+                                <pre className="text-sm bg-gray-100 dark:bg-gray-700 p-2 rounded max-h-24 overflow-auto">
+                                    <code>{events[currentStep].stack.join(' -> ')}</code>
+                                </pre>
+                            </>
+                        )}
+                        {events[currentStep].event === 'return' && events[currentStep].return && (
+                            <p className="mt-2 text-sm">Return Value: {events[currentStep].return}</p>
+                        )}
                     </div>
                 )}
                 <svg ref={svgRef}></svg>


### PR DESCRIPTION
## Summary
- Enhance Python tracer to capture call, line, and return events with call-stack and local variables
- Display event type, call stack, and return values in the front-end execution visualizer

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found; unexpected token errors)*

------
https://chatgpt.com/codex/tasks/task_b_68baaa4f0dc4832bbc3edf119e9a8d5e