### PR TITLE
Improve auth pages with modern UI and password toggle

### DIFF
--- a/client/src/components/PasswordInput.jsx
+++ b/client/src/components/PasswordInput.jsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { TextInput } from 'flowbite-react';
+import { HiEye, HiEyeOff } from 'react-icons/hi';
+
+export default function PasswordInput(props) {
+  const [visible, setVisible] = useState(false);
+  return (
+    <div className="relative">
+      <TextInput type={visible ? 'text' : 'password'} {...props} />
+      <button
+        type="button"
+        onClick={() => setVisible((v) => !v)}
+        className="absolute inset-y-0 right-3 flex items-center text-gray-500"
+        tabIndex={-1}
+      >
+        {visible ? <HiEyeOff /> : <HiEye />}
+      </button>
+    </div>
+  );
+}

--- a/client/src/pages/SignIn.jsx
+++ b/client/src/pages/SignIn.jsx
@@ -1,5 +1,4 @@
 import { Alert, Button, Label, Spinner, TextInput } from 'flowbite-react';
-import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useForm } from 'react-hook-form';
@@ -11,37 +10,30 @@ import {
   signInSuccess,
   signInFailure,
 } from '../redux/user/userSlice';
-import { signInUser } from '../services/authService'; // <-- Import our new service
+import { signInUser } from '../services/authService';
 import OAuth from '../components/OAuth';
+import PasswordInput from '../components/PasswordInput';
 
-// 1. Define the validation schema with Zod
 const signInSchema = z.object({
   email: z.string().email('Please enter a valid email address.'),
   password: z.string().min(6, 'Password must be at least 6 characters long.'),
 });
-
-// Infer the TypeScript type from the schema if you were using TypeScript
-// type SignInFormData = z.infer<typeof signInSchema>;
 
 export default function SignIn() {
   const { loading, error: errorMessage } = useSelector((state) => state.user);
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
-  // 2. Set up React Hook Form
   const {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm({
-    resolver: zodResolver(signInSchema),
-  });
+  } = useForm({ resolver: zodResolver(signInSchema) });
 
-  // 3. The new submit handler is much cleaner
   const handleFormSubmit = async (formData) => {
     try {
       dispatch(signInStart());
-      const data = await signInUser(formData); // Use the service
+      const data = await signInUser(formData);
       dispatch(signInSuccess(data));
       navigate('/');
     } catch (error) {
@@ -50,89 +42,72 @@ export default function SignIn() {
   };
 
   return (
-      <div className='min-h-screen mt-20'>
-        <div className='flex p-3 max-w-3xl mx-auto flex-col md:flex-row md:items-center gap-5'>
-          {/* left */}
-          <div className='flex-1'>
-            <Link to='/' className='font-bold dark:text-white text-4xl'>
+    <div className='min-h-screen flex items-center justify-center bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 dark:from-gray-900 dark:via-gray-900 dark:to-black p-3'>
+      <div className='flex p-6 max-w-3xl w-full bg-white/70 dark:bg-gray-800/70 backdrop-blur-xl rounded-2xl shadow-2xl flex-col md:flex-row md:items-center gap-5'>
+        {/* left */}
+        <div className='flex-1'>
+          <Link to='/' className='font-bold dark:text-white text-4xl'>
             <span className='px-2 py-1 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 rounded-lg text-white'>
               Sahand's
             </span>
-              Blog
-            </Link>
-            <p className='text-sm mt-5'>
-              This is a demo project. You can sign in with your email and password
-              or with Google.
-            </p>
-          </div>
-          {/* right */}
-          <div className='flex-1'>
-            {/* 4. Use the handleSubmit from react-hook-form */}
-            <form
-                className='flex flex-col gap-4'
-                onSubmit={handleSubmit(handleFormSubmit)}
-            >
-              <div>
-                <Label value='Your email' />
-                <TextInput
-                    type='email'
-                    placeholder='name@company.com'
-                    id='email'
-                    // 5. Register the input
-                    {...register('email')}
-                />
-                {/* 6. Show field-specific errors */}
-                {errors.email && (
-                    <p className='text-red-500 text-sm mt-1'>
-                      {errors.email.message}
-                    </p>
-                )}
-              </div>
-              <div>
-                <Label value='Your password' />
-                <TextInput
-                    type='password'
-                    placeholder='**********'
-                    id='password'
-                    // 5. Register the input
-                    {...register('password')}
-                />
-                {/* 6. Show field-specific errors */}
-                {errors.password && (
-                    <p className='text-red-500 text-sm mt-1'>
-                      {errors.password.message}
-                    </p>
-                )}
-              </div>
-              <Button
-                  gradientDuoTone='purpleToPink'
-                  type='submit'
-                  disabled={loading}
-              >
-                {loading ? (
-                    <>
-                      <Spinner size='sm' />
-                      <span className='pl-3'>Loading...</span>
-                    </>
-                ) : (
-                    'Sign In'
-                )}
-              </Button>
-              <OAuth />
-            </form>
-            <div className='flex gap-2 text-sm mt-5'>
-              <span>Don't have an account?</span>
-              <Link to='/sign-up' className='text-blue-500'>
-                Sign Up
-              </Link>
+            Blog
+          </Link>
+          <p className='text-sm mt-5 text-gray-700 dark:text-gray-300'>
+            This is a demo project. You can sign in with your email and password
+            or with Google.
+          </p>
+        </div>
+        {/* right */}
+        <div className='flex-1'>
+          <form className='flex flex-col gap-4' onSubmit={handleSubmit(handleFormSubmit)}>
+            <div>
+              <Label value='Your email' />
+              <TextInput
+                type='email'
+                placeholder='name@company.com'
+                id='email'
+                {...register('email')}
+              />
+              {errors.email && (
+                <p className='text-red-500 text-sm mt-1'>{errors.email.message}</p>
+              )}
             </div>
-            {errorMessage && (
-                <Alert className='mt-5' color='failure'>
-                  {errorMessage}
-                </Alert>
-            )}
+            <div>
+              <Label value='Your password' />
+              <PasswordInput
+                placeholder='**********'
+                id='password'
+                {...register('password')}
+              />
+              {errors.password && (
+                <p className='text-red-500 text-sm mt-1'>{errors.password.message}</p>
+              )}
+            </div>
+            <Button gradientDuoTone='purpleToPink' type='submit' disabled={loading}>
+              {loading ? (
+                <>
+                  <Spinner size='sm' />
+                  <span className='pl-3'>Loading...</span>
+                </>
+              ) : (
+                'Sign In'
+              )}
+            </Button>
+            <OAuth />
+          </form>
+          <div className='flex gap-2 text-sm mt-5'>
+            <span>Don't have an account?</span>
+            <Link to='/sign-up' className='text-blue-500'>
+              Sign Up
+            </Link>
           </div>
+          {errorMessage && (
+            <Alert className='mt-5' color='failure'>
+              {errorMessage}
+            </Alert>
+          )}
         </div>
       </div>
+    </div>
   );
 }

--- a/client/src/pages/SignUp.jsx
+++ b/client/src/pages/SignUp.jsx
@@ -5,10 +5,10 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
-import { signUpUser } from '../services/authService'; // <-- Import our new function
+import { signUpUser } from '../services/authService';
 import OAuth from '../components/OAuth';
+import PasswordInput from '../components/PasswordInput';
 
-// 1. Define a more robust validation schema for sign-up
 const signUpSchema = z.object({
   username: z
       .string()
@@ -22,19 +22,16 @@ const signUpSchema = z.object({
       .regex(/[a-zA-Z]/, 'Password must contain at least one letter.')
       .regex(/[0-9]/, 'Password must contain at least one number.'),
   confirmPassword: z.string(),
-})
-    .refine((data) => data.password === data.confirmPassword, {
-      message: "Passwords do not match.",
-      path: ["confirmPassword"], // Point the error to the confirmPassword field
-    });
+}).refine((data) => data.password === data.confirmPassword, {
+  message: "Passwords do not match.",
+  path: ["confirmPassword"],
+});
 
 export default function SignUp() {
-  // We still use local state for loading and API errors
   const [errorMessage, setErrorMessage] = useState(null);
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
-  // 2. Set up React Hook Form
   const {
     register,
     handleSubmit,
@@ -43,7 +40,6 @@ export default function SignUp() {
     resolver: zodResolver(signUpSchema),
   });
 
-  // 3. The new submit handler for our form
   const handleFormSubmit = async (formData) => {
     setLoading(true);
     setErrorMessage(null);
@@ -58,105 +54,103 @@ export default function SignUp() {
   };
 
   return (
-      <div className='min-h-screen mt-20'>
-        <div className='flex p-3 max-w-3xl mx-auto flex-col md:flex-row md:items-center gap-5'>
-          {/* left */}
-          <div className='flex-1'>
-            <Link to='/' className='font-bold dark:text-white text-4xl'>
+    <div className='min-h-screen flex items-center justify-center bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 dark:from-gray-900 dark:via-gray-900 dark:to-black p-3'>
+      <div className='flex p-6 max-w-3xl w-full bg-white/70 dark:bg-gray-800/70 backdrop-blur-xl rounded-2xl shadow-2xl flex-col md:flex-row md:items-center gap-5'>
+        {/* left */}
+        <div className='flex-1'>
+          <Link to='/' className='font-bold dark:text-white text-4xl'>
             <span className='px-2 py-1 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 rounded-lg text-white'>
               Sahand's
             </span>
-              Blog
-            </Link>
-            <p className='text-sm mt-5'>
-              This is a demo project. You can sign up with your email and password
-              or with Google.
-            </p>
-          </div>
-          {/* right */}
-          <div className='flex-1'>
-            <form
-                className='flex flex-col gap-4'
-                onSubmit={handleSubmit(handleFormSubmit)} // 4. Use RHF's handleSubmit
-                noValidate // Disable native browser validation
-            >
-              <div>
-                <Label value='Your username' />
-                <TextInput
-                    type='text'
-                    placeholder='Username'
-                    id='username'
-                    {...register('username')} // 5. Register the input
-                />
-                {errors.username && ( // 6. Show field-specific error
-                    <p className='text-red-500 text-sm mt-1'>{errors.username.message}</p>
-                )}
-              </div>
-              <div>
-                <Label value='Your email' />
-                <TextInput
-                    type='email'
-                    placeholder='name@company.com'
-                    id='email'
-                    {...register('email')}
-                />
-                {errors.email && (
-                    <p className='text-red-500 text-sm mt-1'>{errors.email.message}</p>
-                )}
-              </div>
-              <div>
-                <Label value='Your password' />
-                <TextInput
-                    type='password'
-                    placeholder='Password'
-                    id='password'
-                    {...register('password')}
-                />
-                {errors.password && (
-                    <p className='text-red-500 text-sm mt-1'>{errors.password.message}</p>
-                )}
-              </div>
-              <div>
-                <Label value='Confirm your password' />
-                <TextInput
-                    type='password'
-                    placeholder='Confirm Password'
-                    id='confirmPassword'
-                    {...register('confirmPassword')}
-                />
-                {errors.confirmPassword && (
-                    <p className='text-red-500 text-sm mt-1'>{errors.confirmPassword.message}</p>
-                )}
-              </div>
-              <Button
-                  gradientDuoTone='purpleToPink'
-                  type='submit'
-                  disabled={loading}
-              >
-                {loading ? (
-                    <>
-                      <Spinner size='sm' />
-                      <span className='pl-3'>Loading...</span>
-                    </>
-                ) : (
-                    'Sign Up'
-                )}
-              </Button>
-              <OAuth />
-            </form>
-            <div className='flex gap-2 text-sm mt-5'>
-              <span>Have an account?</span>
-              <Link to='/sign-in' className='text-blue-500'>
-                Sign In
-              </Link>
+            Blog
+          </Link>
+          <p className='text-sm mt-5 text-gray-700 dark:text-gray-300'>
+            This is a demo project. You can sign up with your email and password
+            or with Google.
+          </p>
+        </div>
+        {/* right */}
+        <div className='flex-1'>
+          <form
+            className='flex flex-col gap-4'
+            onSubmit={handleSubmit(handleFormSubmit)}
+            noValidate
+          >
+            <div>
+              <Label value='Your username' />
+              <TextInput
+                type='text'
+                placeholder='Username'
+                id='username'
+                {...register('username')}
+              />
+              {errors.username && (
+                <p className='text-red-500 text-sm mt-1'>{errors.username.message}</p>
+              )}
             </div>
-            {errorMessage && (
-                <Alert className='mt-5' color='failure'>
-                  {errorMessage}
-                </Alert>
-            )}
+            <div>
+              <Label value='Your email' />
+              <TextInput
+                type='email'
+                placeholder='name@company.com'
+                id='email'
+                {...register('email')}
+              />
+              {errors.email && (
+                <p className='text-red-500 text-sm mt-1'>{errors.email.message}</p>
+              )}
+            </div>
+            <div>
+              <Label value='Your password' />
+              <PasswordInput
+                placeholder='Password'
+                id='password'
+                {...register('password')}
+              />
+              {errors.password && (
+                <p className='text-red-500 text-sm mt-1'>{errors.password.message}</p>
+              )}
+            </div>
+            <div>
+              <Label value='Confirm your password' />
+              <PasswordInput
+                placeholder='Confirm Password'
+                id='confirmPassword'
+                {...register('confirmPassword')}
+              />
+              {errors.confirmPassword && (
+                <p className='text-red-500 text-sm mt-1'>{errors.confirmPassword.message}</p>
+              )}
+            </div>
+            <Button
+              gradientDuoTone='purpleToPink'
+              type='submit'
+              disabled={loading}
+            >
+              {loading ? (
+                <>
+                  <Spinner size='sm' />
+                  <span className='pl-3'>Loading...</span>
+                </>
+              ) : (
+                'Sign Up'
+              )}
+            </Button>
+            <OAuth />
+          </form>
+          <div className='flex gap-2 text-sm mt-5'>
+            <span>Have an account?</span>
+            <Link to='/sign-in' className='text-blue-500'>
+              Sign In
+            </Link>
           </div>
+          {errorMessage && (
+            <Alert className='mt-5' color='failure'>
+              {errorMessage}
+            </Alert>
+          )}
         </div>
       </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable PasswordInput with visibility toggle
- restyle SignIn and SignUp with glassmorphic gradient cards
- integrate new input into auth forms

## Testing
- `npm test` *(fails: Jest encountered an unexpected token and missing jsdom environment)*

------
https://chatgpt.com/codex/tasks/task_b_68bbdd8ea2ac8331a6b153727d676acf